### PR TITLE
If input mapping have Integer, cast it as float

### DIFF
--- a/lib/mizlab.rb
+++ b/lib/mizlab.rb
@@ -49,6 +49,10 @@ module Mizlab
         raise TypeError, "All of `mappings`.values must have same size"
       end
 
+      mappings.each do |k, v|
+        mappings[k] = v.map(&:to_f)
+      end
+
       window_size = (if window_size.nil?
         unless weights.nil?
           weights.keys[0].length


### PR DESCRIPTION
This PR provide process that cast mapping to float.

On current code, when gave mapping and weight are Integer, returned coordinates become Integer too.

This PR prevent it.
