### PR TITLE
:bug: Fix incorrect function call

### DIFF
--- a/lib/mizlab.rb
+++ b/lib/mizlab.rb
@@ -106,7 +106,7 @@ module Mizlab
     end
 
     def fetch_nucleotide(accession)
-      return Bio::NCBI::REST::EFetch.protein(accession)
+      return Bio::NCBI::REST::EFetch.nucleotide(accession)
     end
 
     # get patterns from filled pixs.


### PR DESCRIPTION
This PR is bug fix.

In fetch_nucleotide function, using another function by mistake.
